### PR TITLE
Add displayFormat() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+.idea

--- a/src/DateFilter.php
+++ b/src/DateFilter.php
@@ -50,15 +50,18 @@ class DateFilter extends BaseFilter
                     return [];
                 }
 
+                /** @var string $displayFormat */
+                $displayFormat = $this->evaluate($this->displayFormat);
+
                 if (!$this->range) {
-                    $label = Carbon::parse($state['value'])->format($this->displayFormat);
+                    $label = Carbon::parse($state['value'])->format($displayFormat);
                     return ["{$this->getIndicator()}: {$label}"];
                 }
 
                 $format = fn(string $field) => $state[$field]
                     ? [
                         $this->labels[$field],
-                        Carbon::parse($state[$field])->format($this->displayFormat)
+                        Carbon::parse($state[$field])->format($displayFormat)
                     ] : [];
 
                 $label = implode(' ', array_filter([

--- a/src/DateFilter.php
+++ b/src/DateFilter.php
@@ -27,6 +27,8 @@ class DateFilter extends BaseFilter
 
     protected CarbonInterface | string | Closure | null $minDate = null;
 
+    protected string | Closure | null $displayFormat = 'M j, Y';
+
     protected string | Closure | null $timezone = null;
 
     protected array $labels = [
@@ -38,6 +40,8 @@ class DateFilter extends BaseFilter
     {
         parent::setUp();
 
+        $this->displayFormat = config('tables.date_format', $this->displayFormat);
+
         $this
             ->useColumn($this->getName())
             ->indicateUsing(function (array $state): array {
@@ -46,17 +50,15 @@ class DateFilter extends BaseFilter
                     return [];
                 }
 
-                $displayFormat = config('tables.date_format', 'M j, Y');
-
                 if (!$this->range) {
-                    $label = Carbon::parse($state['value'])->format($displayFormat);
+                    $label = Carbon::parse($state['value'])->format($this->displayFormat);
                     return ["{$this->getIndicator()}: {$label}"];
                 }
 
                 $format = fn(string $field) => $state[$field]
                     ? [
                         $this->labels[$field],
-                        Carbon::parse($state[$field])->format($displayFormat)
+                        Carbon::parse($state[$field])->format($this->displayFormat)
                     ] : [];
 
                 $label = implode(' ', array_filter([
@@ -194,6 +196,13 @@ class DateFilter extends BaseFilter
         return $this;
     }
 
+    public function displayFormat(string | Closure | null $format): static
+    {
+        $this->displayFormat = $format;
+
+        return $this;
+    }
+
     public function timezone(string | Closure | null $timezone): static
     {
         $this->timezone = $timezone;
@@ -214,6 +223,7 @@ class DateFilter extends BaseFilter
                 Forms\Components\DatePicker::make('value')
                     ->closeOnDateSelection()
                     ->label($this->getLabel())
+                    ->displayFormat($this->displayFormat)
                     ->maxDate($this->maxDate)
                     ->minDate($this->minDate)
                     ->timezone($this->timezone)
@@ -230,6 +240,7 @@ class DateFilter extends BaseFilter
                     Forms\Components\DatePicker::make('from')
                         ->closeOnDateSelection()
                         ->label($this->labels['from'])
+                        ->displayFormat($this->displayFormat)
                         ->timezone($this->timezone)
                         ->minDate($this->minDate)
                         ->maxDate(fn($get) => $get('until') ?? $this->maxDate),
@@ -237,6 +248,7 @@ class DateFilter extends BaseFilter
                     Forms\Components\DatePicker::make('until')
                         ->closeOnDateSelection()
                         ->label($this->labels['until'])
+                        ->displayFormat($this->displayFormat)
                         ->timezone($this->timezone)
                         ->minDate(fn($get) => $get('from') ?? $this->minDate)
                         ->maxDate($this->maxDate),


### PR DESCRIPTION
It wasn't using the date display format on the DatePicker component. This was fixed. Also, I've added a shortcut to set the date display format.